### PR TITLE
Set nuxt version to 0.10.7

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "0.10.7",
     "vue-server-renderer": "latest",
     "vuetify": "latest"
   },


### PR DESCRIPTION
Since nuxt released version 1.0.0-alpha1 on npm along with its breaking changes, current template would not work.

It would be wise to adapt to Nuxt 1.0 but it is not stable enough yet in my opinion.