### PR TITLE
Fix Nuxt.js deprecation warning

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -51,7 +51,7 @@ module.exports = {
     ** Run ESLint on save
     */
     extend (config, ctx) {
-      if (ctx.dev && ctx.isClient) {
+      if (ctx.isDev && ctx.isClient) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,


### PR DESCRIPTION
Fix for `dev has been deprecated in build.extend(), please use isDev`.