### PR TITLE
Fix: eslint error after migrating to Nuxt v2

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -51,7 +51,7 @@ module.exports = {
     ** Run ESLint on save
     */
     extend (config, {isDev}) {
-      if (isDev && process.isClient) {
+      if (isDev && process.client) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,

--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -50,8 +50,8 @@ module.exports = {
     /*
     ** Run ESLint on save
     */
-    extend (config, ctx) {
-      if (ctx.isDev && ctx.isClient) {
+    extend (config, {isDev}) {
+      if (isDev && process.isClient) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,
@@ -60,7 +60,7 @@ module.exports = {
         })
       }
       {{#alacarte}}
-      if (ctx.isServer) {
+      if (process.server) {
         config.externals = [
           nodeExternals({
             whitelist: [/^vuetify/]


### PR DESCRIPTION
error :
```
Module build failed (from ./node_modules/eslint-loader/index.js):
TypeError: Cannot read property 'eslint' of undefined
at Object.module.exports (/Users/fbernard/tmp/test/node_modules/eslint-loader/index.js:148:18) 
```
`isClient & isServer ` **are Deprecated**

after running `npm run`  if you are using  `A-la-carte` in your template  you may face this error about stylus

node_modules/vuetify/src/stylus/components/_app.styl:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){@import '../bootstrap'

~~to fix it go to node_modules/vuetify/src/stylus/components there open **`_app.styl`**
remove the line no:1
**`@import '../bootstrap'`**~~
I dont have a fix for it now :-(

@johnleider Please take a look at this