### PR TITLE
Automatically Update Copyright Year

### DIFF
--- a/template/layouts/default.vue
+++ b/template/layouts/default.vue
@@ -74,7 +74,7 @@
       </v-list>
     </v-navigation-drawer>
     <v-footer :fixed="fixed" app>
-      <span>&copy; 2017</span>
+      <span>&copy; {{ new Date().getFullYear() }}</span>
     </v-footer>
   </v-app>
 </template>


### PR DESCRIPTION
Instead of having to update the copyright year manually, get the current year via javascript.