### PR TITLE
Fix copyright year syntax

### DIFF
--- a/template/layouts/default.vue
+++ b/template/layouts/default.vue
@@ -74,7 +74,7 @@
       </v-list>
     </v-navigation-drawer>
     <v-footer :fixed="fixed" app>
-      <span>&copy; {{ new Date().getFullYear() }}</span>
+      <span>&copy; \{{ new Date().getFullYear() }}</span>
     </v-footer>
   </v-app>
 </template>


### PR DESCRIPTION
I forgot vue init tries to parse `{{  }}`, and thus caused error when trying to use.

This properly escapes the mustache syntax in the component so that it doesn't cause any error now. `\{{  }}`

![image](https://user-images.githubusercontent.com/13877593/46474797-a6ab4a00-c798-11e8-992e-daa0f2326f5e.png)