### PR TITLE
Fix a-la-carte components and eslint for Nuxt v2

### DIFF
--- a/template/assets/style/app.styl
+++ b/template/assets/style/app.styl
@@ -1,8 +1,21 @@
+// Import and define Vuetify color theme
+// https://vuetifyjs.com/en/style/colors
+@require '~vuetify/src/stylus/settings/_colors'
+$theme := {
+  primary:     $blue.darken-2
+  accent:      $blue.accent-2
+  secondary:   $grey.lighten-1
+  info:        $blue.lighten-1
+  warning:     $amber.darken-2
+  error:       $red.accent-4
+  success:     $green.lighten-2
+}
+
 // Import Vuetify styling
 {{#alacarte}}
-@require '~vuetify/src/stylus/app.styl'
+@require '~vuetify/src/stylus/app'
 {{else}}
-@require '~vuetify/src/stylus/main.styl'
+@require '~vuetify/src/stylus/main'
 {{/alacarte}}
 
 .page

--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -1,9 +1,4 @@
-{{#alacarte}}
-const nodeExternals = require('webpack-node-externals')
-const resolve = (dir) => require('path').join(__dirname, dir)
-{{/alacarte}}
-
-module.exports = {
+export default {
   /*
   ** Headers of the page
   */
@@ -32,26 +27,24 @@ module.exports = {
   */
   build: {
     {{#alacarte}}
+    transpile: [/^vuetify/],
     babel: {
       plugins: [
-        ["transform-imports", {
-          "vuetify": {
-            "transform": "vuetify/es5/components/${member}",
-            "preventFullImport": true
+        ['transform-imports', {
+          'vuetify': {
+            'transform': 'vuetify/es5/components/${member}',
+            'preventFullImport': true
           }
         }]
       ]
     },
     {{/alacarte}}
-    vendor: [
-      '~/plugins/vuetify.js'
-    ],
     extractCSS: true,
     /*
     ** Run ESLint on save
     */
-    extend (config, ctx) {
-      if (ctx.isDev && ctx.isClient) {
+    extend (config, {isDev}) {
+      if (isDev && process.client) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,
@@ -60,7 +53,7 @@ module.exports = {
         })
       }
       {{#alacarte}}
-      if (ctx.isServer) {
+      if (process.server) {
         config.externals = [
           nodeExternals({
             whitelist: [/^vuetify/]

--- a/template/package.json
+++ b/template/package.json
@@ -11,8 +11,8 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
-    "nuxt": "^2.0.0",
-    "vuetify": "^1.2.5"
+    "nuxt": "^2.1.0",
+    "vuetify": "^1.2.6"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
I noticed a few issues from @Codefa's PR #56 and spent a little time fixing all the various errors that were appearing in Nuxt v2.

To test this PR, just specify the nuxt2 branch from my repo.

```cmd
$ vue init XanderLuciano/nuxt#nuxt2 my-project
```

Error free a-la-carte :)

![image](https://user-images.githubusercontent.com/13877593/46482993-85a02480-c7ab-11e8-93d5-65a4114467da.png)

