### PR TITLE
Fix incorrect client / server detection.

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -43,8 +43,8 @@ export default {
     /*
     ** Run ESLint on save
     */
-    extend (config, {isDev}) {
-      if (isDev && process.client) {
+    extend (config, {isDev, isClient, isServer}) {
+      if (isDev && isClient) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,
@@ -53,7 +53,7 @@ export default {
         })
       }
       {{#alacarte}}
-      if (process.server) {
+      if (isServer) {
         config.externals = [
           nodeExternals({
             whitelist: [/^vuetify/]


### PR DESCRIPTION
Previously I had believed that isClient and isServer were deprecated due to a misunderstanding of Nuxt's docs.
This led to an incorrect change of `isClient` and `isServer` to `process.client` and `process.server` which at this point are underfined, as you can see by logging the variables to the console:

![image](https://user-images.githubusercontent.com/13877593/47347429-11e39000-d664-11e8-905c-c9ff659bc580.png)

This was confirmed by a core nuxt developer.

![image](https://user-images.githubusercontent.com/13877593/47347522-3f303e00-d664-11e8-8b73-e8ab0b1b7c34.png)
